### PR TITLE
Automatically name zip archive

### DIFF
--- a/slice_sample.py
+++ b/slice_sample.py
@@ -6,10 +6,9 @@ sound = AudioSegment.from_wav(sys.argv[1])
 slice_length = int(len(sound) / int(sys.argv[2]))
 slice_indicator = "slice_"
 audio_range = int(len(sound)/(len(sound) / int(sys.argv[2])))
-print(f"clip length: {len(sound)}")
-print(f"slice length: {slice_length}")
-print(f"slicing {sys.argv[1]} to {sys.argv[2]} slices ...")
+archive_name = sys.argv[2]+"_"+ sys.argv[1][sys.argv[1].rfind("/")+1:-4].replace(" ", "_") + ".zip"
 
+print(f"slicing {sys.argv[1]} to {sys.argv[2]} slices ...")
 
 note = ["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"]
 note_count = 0
@@ -33,10 +32,10 @@ for sl in range(audio_range):
 
 file_name = glob.glob(f'./*{slice_indicator}*.wav')
 if len(sys.argv) < 4:
-	with ZipFile(f'{sys.argv[2]}_chopped.zip', 'w') as myzip:
+	with ZipFile(f'{archive_name}', 'w') as myzip:
 		for f in file_name:
 			myzip.write(f)
 			os.remove(f)
-	print("Archive created.")
+	print(f"Archive {archive_name} created.")
 else:
 	print("Slicing complete, please preview your files")


### PR DESCRIPTION
Grabs the name of the audio file and uses it for naming zip archive according to this naming convention:
<slice count>_<file name>.zip

If the path is a folder structure, the path up to the file name will be discarded:
folder/subfolder/file name.wav 
will return the name:
64_file name.zip